### PR TITLE
Make `changed` lifecycle hook fire when Redux watched properties change

### DIFF
--- a/lib/components/connect.ts
+++ b/lib/components/connect.ts
@@ -67,6 +67,13 @@ export function connect<S, A extends Action, C = any>(defaultStore?: Store<S, A>
                                     currentValue = nextValue;
                                     this[String(name)] = transform(currentValue, oldValue, source);
                                 }
+
+                                // Trigger changed lifecycle hook when props from store change
+                                if (this.changed === 'function') {
+                                    const changedProperties = new Map()
+                                    changedProperties.set(String(name), nextValue);
+                                    this.changed(changedProperties)
+                                }
                             }
                         }));
                     },


### PR DESCRIPTION
This will trigger the `changed` LitElement lifecycle hook, but it will trigger once for every watched property, even if all of those properties had changed simultaneously.